### PR TITLE
Add Highwire Press meta tags for citation info

### DIFF
--- a/main.py
+++ b/main.py
@@ -120,6 +120,7 @@ def format_paper(v):
             "TLDR": v["abstract"],
             "recs": [],
             "session": v.get("session", "").split("|"),
+            "pdf_url": v.get("pdf_url", ""),
         },
     }
 

--- a/sitedata/README.md
+++ b/sitedata/README.md
@@ -9,6 +9,7 @@ the required data fields are provided.
 - name: `<short name>`
 - tagline: `<long name>`
 - date: `<Date of conference>`
+- proceedings_title: `<proceedings name for citation>`
 - analytics: `<Google analytics ID starting with UA... >`
 - logo: `<link to logo>`
 - organization: `<conference committee name>`

--- a/sitedata/README.md
+++ b/sitedata/README.md
@@ -8,7 +8,7 @@ the required data fields are provided.
 
 - name: `<short name>`
 - tagline: `<long name>`
-- data: `<Date of conference>`
+- date: `<Date of conference>`
 - analytics: `<Google analytics ID starting with UA... >`
 - logo: `<link to logo>`
 - organization: `<conference committee name>`

--- a/sitedata/config.yml
+++ b/sitedata/config.yml
@@ -1,6 +1,7 @@
 name: MiniConf
 tagline: MINICONF <br> CONFERENCE <br> MANAGEMENT
 data: May 2020
+proceedings_title: Proceedings of the First MiniCon Conference
 analytics: UA-
 logo: static/images/MiniConf.png
 organization: MiniConf Organization Committee

--- a/templates/poster.html
+++ b/templates/poster.html
@@ -7,8 +7,8 @@
 {% for author in paper.content.authors %}
 <meta name="citation_author" content="{{author}}" />
 {% endfor %}
-<meta name="citation_publication_date" content="{{config.data}}" />
 <meta name="citation_conference_title" content="{{config.name}}" />
+<meta name="citation_publication_date" content="{{config.date}}" />
 <meta name="citation_abstract" content="{{paper.content.abstract}}" />
 {% for keyword in paper.content.keywords %}
 <meta name="citation_keywords" content="{{keyword}}" />

--- a/templates/poster.html
+++ b/templates/poster.html
@@ -7,13 +7,14 @@
 {% for author in paper.content.authors %}
 <meta name="citation_author" content="{{author}}" />
 {% endfor %}
-<meta name="citation_conference_title" content="{{config.name}}" />
 <meta name="citation_publication_date" content="{{config.date}}" />
+<meta name="citation_conference_title" content="{{config.tagline|striptags|title}}" />
+<meta name="citation_inbook_title" content="{{config.proceedings_title}}" />
 <meta name="citation_abstract" content="{{paper.content.abstract}}" />
 {% for keyword in paper.content.keywords %}
 <meta name="citation_keywords" content="{{keyword}}" />
 {% endfor %}
-<!-- <meta name="citation_pdf_url" content="" /> -->
+<meta name="citation_pdf_url" content="{{paper.content.pdf_url | default("")}}" />
 
 {% endblock %}
 

--- a/templates/poster.html
+++ b/templates/poster.html
@@ -1,4 +1,22 @@
 {% extends "base.html" %}
+
+{% block head %}
+
+{{ super() }}
+<meta name="citation_title" content="{{paper.content.title}}" />
+{% for author in paper.content.authors %}
+<meta name="citation_author" content="{{author}}" />
+{% endfor %}
+<meta name="citation_publication_date" content="{{config.data}}" />
+<meta name="citation_conference_title" content="{{config.name}}" />
+<meta name="citation_abstract" content="{{paper.content.abstract}}" />
+{% for keyword in paper.content.keywords %}
+<meta name="citation_keywords" content="{{keyword}}" />
+{% endfor %}
+<!-- <meta name="citation_pdf_url" content="" /> -->
+
+{% endblock %}
+
 {% block content %}
 
 <!-- Title -->


### PR DESCRIPTION
Adds metadata that can be picked up by citation managers like Zotero and Mendeley. The change here is the same as https://github.com/ICLR/iclr.github.io/pull/69.

One question - I'd like to have used `tagline` in `config.yml` as the conference name here instead of the short `name`, but the former has HTML markup. This could be stripped somewhere in code, but thought I'd ask for thoughts beforehand. 

Thanks!