### PR TITLE
Add titles to pages (fixes #23)

### DIFF
--- a/sitedata/README.md
+++ b/sitedata/README.md
@@ -15,6 +15,9 @@ the required data fields are provided.
     - width: `<width of the image> or "auto"`
     - height: `<height of the image> or "auto"`
 - site_title: `<name of the site>`
+- page_title:
+    - prefix: `<text to include in title of every page>`
+    - separator: `<characters between prefix and name of the current page>`
 - background_image: `<link to background image>`
 - organization: `<conference committee name>`
 

--- a/sitedata/config.yml
+++ b/sitedata/config.yml
@@ -8,6 +8,9 @@ logo:
   height: auto
 # uncomment the following line to show the site title next to the logo image
 # site_title: MiniConf
+page_title:
+  prefix: 'MiniConf 2020'
+  separator: ': '
 background_image: static/images/main.jpg
 organization: MiniConf Organization Committee
 calendar:

--- a/templates/about.html
+++ b/templates/about.html
@@ -1,4 +1,5 @@
 {% set active_page = "Help" %}
+{% set page_title = "Help" %}
 {% extends "base.html" %}
 
 {% block tabs %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -70,7 +70,7 @@
       rel="stylesheet"
     />
 
-    <title>{{config.page_title}}</title>
+    <title>{{config.page_title.prefix}}{% if page_title %}{{config.page_title.separator}}{{page_title}}{% endif %}</title>
     {% endblock %}
   </head>
 

--- a/templates/papers.html
+++ b/templates/papers.html
@@ -1,4 +1,5 @@
 {% set active_page = "Papers" %}
+{% set page_title = "Papers" %}
 
 {% extends "base.html" %}
 {% block head %}

--- a/templates/papers_vis.html
+++ b/templates/papers_vis.html
@@ -1,3 +1,4 @@
+{% set page_title = "Paper Explorer" %}
 {% extends "base.html" %}
 {% block head %}
 {{ super() }}

--- a/templates/poster.html
+++ b/templates/poster.html
@@ -1,3 +1,4 @@
+{% set page_title = paper.content.title %}
 {% extends "base.html" %}
 {% block content %}
 

--- a/templates/schedule.html
+++ b/templates/schedule.html
@@ -1,4 +1,5 @@
 {% set active_page = "Schedule" %}
+{% set page_title = "Schedule" %}
 {% extends "base.html" %}
 {% block head %}
 {{ super() }}

--- a/templates/speaker.html
+++ b/templates/speaker.html
@@ -1,3 +1,4 @@
+{% set page_title = speaker.title %}
 {% extends "base.html" %}
 {% block content %}
 

--- a/templates/workshop.html
+++ b/templates/workshop.html
@@ -1,3 +1,4 @@
+{% set page_title = workshop.title %}
 {% extends "base.html" %}
 {% block content %}
 

--- a/templates/workshops.html
+++ b/templates/workshops.html
@@ -1,4 +1,5 @@
 {% set active_page = "Workshops" %}
+{% set page_title = "Workshops" %}
 {% extends "base.html" %}
 
 {% block content %}


### PR DESCRIPTION
Uses a common prefix for all pages ("MiniConf 2020"), with page-specific titles set using the `page_title` variable. I've followed the ICLR website as far as possible (e.g. speaker pages are titled with the talk title, posters with the paper title etc.).