### PR TITLE
Fix workshop organiser formatting + yaml/json paper data

### DIFF
--- a/main.py
+++ b/main.py
@@ -109,17 +109,25 @@ def workshops():
 
 
 def format_paper(v):
+    list_keys = ["authors", "keywords", "session"]
+    list_fields = {}
+    for key in list_keys:
+        if type(v.get(key, "")) == list:
+            list_fields[key] = v.get(key, "")
+        else:
+            list_fields[key] = v.get(key, "").split("|")
+
     return {
         "id": v["UID"],
         "forum": v["UID"],
         "content": {
             "title": v["title"],
-            "authors": v["authors"].split("|"),
-            "keywords": v["keywords"].split("|"),
+            "authors": list_fields["authors"],
+            "keywords": list_fields["keywords"],
             "abstract": v["abstract"],
             "TLDR": v["abstract"],
             "recs": [],
-            "session": v.get("session", "").split("|"),
+            "session": list_fields["session"],
             "pdf_url": v.get("pdf_url", ""),
         },
     }

--- a/main.py
+++ b/main.py
@@ -110,14 +110,19 @@ def workshops():
     return render_template("workshops.html", **data)
 
 
+def extract_list_field(v, key):
+    value = v.get(key, "")
+    if isinstance(value, list):
+        return value
+    else:
+        return value.split("|")
+
+
 def format_paper(v):
     list_keys = ["authors", "keywords", "session"]
     list_fields = {}
     for key in list_keys:
-        if isinstance(v.get(key, ""), list):
-            list_fields[key] = v.get(key, "")
-        else:
-            list_fields[key] = v.get(key, "").split("|")
+        list_fields[key] = extract_list_field(v, key)
 
     return {
         "id": v["UID"],
@@ -139,10 +144,7 @@ def format_workshop(v):
     list_keys = ["authors"]
     list_fields = {}
     for key in list_keys:
-        if isinstance(v.get(key, ""), list):
-            list_fields[key] = v.get(key, "")
-        else:
-            list_fields[key] = v.get(key, "").split("|")
+        list_fields[key] = extract_list_field(v, key)
 
     return {
         "id": v["UID"],

--- a/main.py
+++ b/main.py
@@ -104,7 +104,9 @@ def schedule():
 @app.route("/workshops.html")
 def workshops():
     data = _data()
-    data["workshops"] = [format_workshop(workshop) for workshop in site_data["workshops"]]
+    data["workshops"] = [
+        format_workshop(workshop) for workshop in site_data["workshops"]
+    ]
     return render_template("workshops.html", **data)
 
 

--- a/main.py
+++ b/main.py
@@ -114,7 +114,7 @@ def format_paper(v):
     list_keys = ["authors", "keywords", "session"]
     list_fields = {}
     for key in list_keys:
-        if type(v.get(key, "")) == list:
+        if isinstance(v.get(key, ""), list):
             list_fields[key] = v.get(key, "")
         else:
             list_fields[key] = v.get(key, "").split("|")
@@ -139,7 +139,7 @@ def format_workshop(v):
     list_keys = ["authors"]
     list_fields = {}
     for key in list_keys:
-        if type(v.get(key, "")) == list:
+        if isinstance(v.get(key, ""), list):
             list_fields[key] = v.get(key, "")
         else:
             list_fields[key] = v.get(key, "").split("|")

--- a/main.py
+++ b/main.py
@@ -104,7 +104,7 @@ def schedule():
 @app.route("/workshops.html")
 def workshops():
     data = _data()
-    data["workshops"] = site_data["workshops"]
+    data["workshops"] = [format_workshop(workshop) for workshop in site_data["workshops"]]
     return render_template("workshops.html", **data)
 
 
@@ -122,6 +122,23 @@ def format_paper(v):
             "session": v.get("session", "").split("|"),
             "pdf_url": v.get("pdf_url", ""),
         },
+    }
+
+
+def format_workshop(v):
+    list_keys = ["authors"]
+    list_fields = {}
+    for key in list_keys:
+        if type(v.get(key, "")) == list:
+            list_fields[key] = v.get(key, "")
+        else:
+            list_fields[key] = v.get(key, "").split("|")
+
+    return {
+        "id": v["UID"],
+        "title": v["title"],
+        "organizers": list_fields["authors"],
+        "abstract": v["abstract"],
     }
 
 
@@ -151,7 +168,7 @@ def workshop(workshop):
     uid = workshop
     v = by_uid["workshops"][uid]
     data = _data()
-    data["workshop"] = v
+    data["workshop"] = format_workshop(v)
     return render_template("workshop.html", **data)
 
 

--- a/templates/components.html
+++ b/templates/components.html
@@ -207,13 +207,15 @@
         class="card-header text-center"
         style="min-height: 200px; width: 100%;"
       >
-        <a class="text-muted" href="workshop_{{workshop.UID}}.html">
+        <a class="text-muted" href="workshop_{{workshop.id}}.html">
           <h3 class="card-title main-title">
             {{workshop.title}}
           </h3>
         </a>
         <div class="card-subtitle text-muted">
-          {{workshop.organizers}}
+          {% for organizer in workshop.organizers %}
+            {{ organizer }}{{ "," if not loop.last }}
+          {% endfor %}
         </div>
         <div class="m-3 text-left card-subtitle font-italic">
           {{workshop.abstract|safe}}

--- a/templates/components.html
+++ b/templates/components.html
@@ -213,9 +213,7 @@
           </h3>
         </a>
         <div class="card-subtitle text-muted">
-          {% for organizer in workshop.organizers %}
-            {{ organizer }}{{ "," if not loop.last }}
-          {% endfor %}
+          {{ workshop.organizers | join(", ") }}
         </div>
         <div class="m-3 text-left card-subtitle font-italic">
           {{workshop.abstract|safe}}

--- a/templates/workshop.html
+++ b/templates/workshop.html
@@ -9,9 +9,7 @@
       {{workshop.title}}
     </h2>
     <h3 class="card-subtitle mb-2 text-muted text-center">
-      {% for organizer in workshop.organizers %}
-        {{ organizer }}{{ "," if not loop.last }}
-      {% endfor %}
+      {{ workshop.organizers | join(", ") }}
     </h3>
     <div class="text-center p-3">
       <a class="card-link" data-toggle="collapse" role="button" href="#details">

--- a/templates/workshop.html
+++ b/templates/workshop.html
@@ -9,7 +9,9 @@
       {{workshop.title}}
     </h2>
     <h3 class="card-subtitle mb-2 text-muted text-center">
-      {{workshop.authors}}
+      {% for organizer in workshop.organizers %}
+        {{ organizer }}{{ "," if not loop.last }}
+      {% endfor %}
     </h3>
     <div class="text-center p-3">
       <a class="card-link" data-toggle="collapse" role="button" href="#details">


### PR DESCRIPTION
* Fix workshop organisers not showing up on workshop listing page
* Fix formatting of organisers on each workshop's own page (previously was pipe-separated as in the csv files, now comma separated).
*  Fix handling of paper data stored as yaml/json, where authors/keywords/sessions will already be parsed as lists and not require the `.split("|")` that csv does. Markup looks like:

```yaml
- UID: B1xSperKvH
  title: Enabling Deep Spiking Neural Networks with Hybrid Conversion and Spike Timing Dependent Backpropagation
  authors:
  - Author 1
  - Author 2
  abstract: 'lorem ipsum dolor'
  keywords:
  - imagenet
  session:
  - ''
```

```json
[
    {
        "UID": "B1xSperKvH",
        "title": "Enabling Deep Spiking Neural Networks with Hybrid Conversion and Spike Timing Dependent Backpropagation",
        "authors": [
            "Author 1",
            "Author 2"
        ],
        "abstract": "lorem ipsum dolor",
        "keywords": [
            "imagenet"
        ],
        "session": [
            ""
        ]
    }
]
```