### PR TITLE
Move some util methods outside main.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PYTHON_FILES = main.py scripts/
+PYTHON_FILES = main.py miniconf/ scripts/
 JS_FILES = $(shell find static/js -name "*.js")
 CSS_FILES = $(shell find static/css -name "*.css")
 .PHONY: format-python format-web format run freeze format-check

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PYTHON_FILES = main.py miniconf/ scripts/
+PYTHON_FILES = main.py miniconf/ scripts/ chat/
 JS_FILES = $(shell find static/js -name "*.js")
 CSS_FILES = $(shell find static/css -name "*.css")
 .PHONY: format-python format-web format run freeze format-check

--- a/chat/make_poster_rooms.py
+++ b/chat/make_poster_rooms.py
@@ -1,51 +1,44 @@
 import argparse
 import csv
-import random
-import string
 
-from requests import sessions
-from pprint import pprint
-from rocketchat_API.rocketchat import RocketChat
 import yaml
+from requests import sessions
+from rocketchat_API.rocketchat import RocketChat
+
 
 def parse_arguments():
     parser = argparse.ArgumentParser(description="MiniConf Portal Command Line")
     parser.add_argument("--config", default="config.yml", help="Configuration yaml")
     parser.add_argument("--papers", default="../sitedata/papers.csv", help="Papers CSV")
-    parser.add_argument("--test", action='store_true')
+    parser.add_argument("--test", action="store_true")
     return parser.parse_args()
 
 
 if __name__ == "__main__":
     args = parse_arguments()
 
-
     config = yaml.load(open(args.config))
     papers = list(csv.DictReader(open(args.papers)))
 
     with sessions.Session() as session:
-        rocket = RocketChat(config["username"],
-                            config["password"],
-                            server_url=config["server"],
-                            session=session)
+        rocket = RocketChat(
+            config["username"],
+            config["password"],
+            server_url=config["server"],
+            session=session,
+        )
 
         for paper in papers:
             channel_name = "paper_" + paper["UID"]
             if not args.test:
                 created = rocket.channels_create(channel_name).json()
                 print(channel_name, created)
-            id = rocket.channels_info(channel = channel_name).json()["channel"]["_id"]
+            channel_info = rocket.channels_info(channel=channel_name).json()
+            room_id = channel_info["channel"]["_id"]
 
-            
-            # Change to topic of papers. 
-            topic = "%s - %s"%(
-                paper["title"],
-                paper["authors"],
-            )
+            # Change to topic of papers.
+            topic = "%s - %s" % (paper["title"], paper["authors"],)
             if not args.test:
-                rocket.channels_set_topic(id, topic).json()
+                rocket.channels_set_topic(room_id, topic).json()
 
             print("Creating " + channel_name + " topic " + topic)
-
-
-

--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+# pylint: disable=redefined-outer-name
 import argparse
 import os
 from typing import Any, Dict
@@ -149,9 +150,9 @@ def generator():
 
     for paper in site_data["papers"]:
         yield "poster", {"poster": str(paper["UID"])}
-    for speaker in site_data["speakers"]:  # pylint: disable=redefined-outer-name
+    for speaker in site_data["speakers"]:
         yield "speaker", {"speaker": str(speaker["UID"])}
-    for workshop in site_data["workshops"]:  # pylint: disable=redefined-outer-name
+    for workshop in site_data["workshops"]:
         yield "workshop", {"workshop": str(workshop["UID"])}
 
     for key in site_data:

--- a/main.py
+++ b/main.py
@@ -1,11 +1,7 @@
-# pylint: disable=global-statement,redefined-outer-name
 import argparse
-import csv
-import glob
-import json
 import os
+from typing import Any, Dict
 
-import yaml
 from flask import Flask, jsonify, redirect, render_template, send_from_directory
 from flask_frozen import Freezer
 from flaskext.markdown import Markdown
@@ -13,8 +9,8 @@ from flaskext.markdown import Markdown
 from miniconf.load_site_data import load_site_data
 from miniconf.utils import format_paper, format_workshop
 
-site_data = {}
-by_uid = {}
+site_data: Dict[str, Any] = {}
+by_uid: Dict[str, Any] = {}
 
 # ------------- SERVER CODE -------------------->
 
@@ -27,9 +23,7 @@ markdown = Markdown(app)
 
 
 def _data():
-    data = {}
-    data["config"] = site_data["config"]
-    return data
+    return {"config": site_data["config"]}
 
 
 @app.route("/")
@@ -63,7 +57,7 @@ def papers():
 
 
 @app.route("/paper_vis.html")
-def paperVis():
+def paper_vis():
     data = _data()
     return render_template("papers_vis.html", **data)
 
@@ -92,27 +86,24 @@ def workshops():
 # ITEM PAGES
 
 
-@app.route("/poster_<poster>.html")
-def poster(poster):
-    uid = poster
+@app.route("/poster_<uid>.html")
+def poster(uid):
     v = by_uid["papers"][uid]
     data = _data()
     data["paper"] = format_paper(v)
     return render_template("poster.html", **data)
 
 
-@app.route("/speaker_<speaker>.html")
-def speaker(speaker):
-    uid = speaker
+@app.route("/speaker_<uid>.html")
+def speaker(uid):
     v = by_uid["speakers"][uid]
     data = _data()
     data["speaker"] = v
     return render_template("speaker.html", **data)
 
 
-@app.route("/workshop_<workshop>.html")
-def workshop(workshop):
-    uid = workshop
+@app.route("/workshop_<uid>.html")
+def workshop(uid):
     v = by_uid["workshops"][uid]
     data = _data()
     data["workshop"] = format_workshop(v)
@@ -155,9 +146,9 @@ def generator():
 
     for paper in site_data["papers"]:
         yield "poster", {"poster": str(paper["UID"])}
-    for speaker in site_data["speakers"]:
+    for speaker in site_data["speakers"]:  # pylint: disable=redefined-outer-name
         yield "speaker", {"speaker": str(speaker["UID"])}
-    for workshop in site_data["workshops"]:
+    for workshop in site_data["workshops"]:  # pylint: disable=redefined-outer-name
         yield "workshop", {"workshop": str(workshop["UID"])}
 
     for key in site_data:
@@ -184,8 +175,7 @@ def parse_arguments():
 
     parser.add_argument("path", help="Pass the JSON data path and run the server")
 
-    args = parser.parse_args()
-    return args
+    return parser.parse_args()
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -86,24 +86,27 @@ def workshops():
 # ITEM PAGES
 
 
-@app.route("/poster_<uid>.html")
-def poster(uid):
+@app.route("/poster_<poster>.html")
+def poster(poster):
+    uid = poster
     v = by_uid["papers"][uid]
     data = _data()
     data["paper"] = format_paper(v)
     return render_template("poster.html", **data)
 
 
-@app.route("/speaker_<uid>.html")
-def speaker(uid):
+@app.route("/speaker_<speaker>.html")
+def speaker(speaker):
+    uid = speaker
     v = by_uid["speakers"][uid]
     data = _data()
     data["speaker"] = v
     return render_template("speaker.html", **data)
 
 
-@app.route("/workshop_<uid>.html")
-def workshop(uid):
+@app.route("/workshop_<workshop>.html")
+def workshop(workshop):
+    uid = workshop
     v = by_uid["workshops"][uid]
     data = _data()
     data["workshop"] = format_workshop(v)

--- a/miniconf/load_site_data.py
+++ b/miniconf/load_site_data.py
@@ -1,0 +1,30 @@
+import csv
+import glob
+import json
+from typing import Any, Dict, List
+
+import yaml
+
+
+def load_site_data(
+    site_data_path: str, site_data: Dict[str, Any], by_uid: Dict[str, Any]
+) -> List[str]:
+    """Load all for your sitedata one time."""
+    extra_files = ["README.md"]
+    for f in glob.glob(site_data_path + "/*"):
+        extra_files.append(f)
+        name, typ = f.split("/")[-1].split(".")
+        if typ == "json":
+            site_data[name] = json.load(open(f))
+        elif typ in {"csv", "tsv"}:
+            site_data[name] = list(csv.DictReader(open(f)))
+        elif typ == "yml":
+            site_data[name] = yaml.load(open(f).read(), Loader=yaml.SafeLoader)
+
+    for typ in ["papers", "speakers", "workshops"]:
+        by_uid[typ] = {}
+        for p in site_data[typ]:
+            by_uid[typ][p["UID"]] = p
+
+    print("Data Successfully Loaded")
+    return extra_files

--- a/miniconf/load_site_data.py
+++ b/miniconf/load_site_data.py
@@ -26,9 +26,10 @@ def load_site_data(
                 site_data[name] = yaml.load(file.read(), Loader=yaml.SafeLoader)
 
     for typ in ["papers", "speakers", "workshops"]:
-        by_uid[typ] = {}
-        for p in site_data[typ]:
-            by_uid[typ][p["UID"]] = p
+        by_uid[typ] = {
+            p["UID"]: p
+            for p in site_data[typ]
+        }
 
     print("Data Successfully Loaded")
     return extra_files

--- a/miniconf/load_site_data.py
+++ b/miniconf/load_site_data.py
@@ -26,10 +26,7 @@ def load_site_data(
                 site_data[name] = yaml.load(file.read(), Loader=yaml.SafeLoader)
 
     for typ in ["papers", "speakers", "workshops"]:
-        by_uid[typ] = {
-            p["UID"]: p
-            for p in site_data[typ]
-        }
+        by_uid[typ] = {p["UID"]: p for p in site_data[typ]}
 
     print("Data Successfully Loaded")
     return extra_files

--- a/miniconf/load_site_data.py
+++ b/miniconf/load_site_data.py
@@ -14,15 +14,16 @@ def load_site_data(
     Populates the `site_data` and `by_uid` using files under `site_data_path`.
     """
     extra_files = ["README.md"]
-    for f in glob.glob(site_data_path + "/*"):
-        extra_files.append(f)
-        name, typ = f.split("/")[-1].split(".")
-        if typ == "json":
-            site_data[name] = json.load(open(f))
-        elif typ in {"csv", "tsv"}:
-            site_data[name] = list(csv.DictReader(open(f)))
-        elif typ == "yml":
-            site_data[name] = yaml.load(open(f).read(), Loader=yaml.SafeLoader)
+    for path in glob.glob(site_data_path + "/*"):
+        extra_files.append(path)
+        name, typ = path.split("/")[-1].split(".")
+        with open(path) as file:
+            if typ == "json":
+                site_data[name] = json.load(file)
+            elif typ in {"csv", "tsv"}:
+                site_data[name] = list(csv.DictReader(file))
+            elif typ == "yml":
+                site_data[name] = yaml.load(file.read(), Loader=yaml.SafeLoader)
 
     for typ in ["papers", "speakers", "workshops"]:
         by_uid[typ] = {}

--- a/miniconf/load_site_data.py
+++ b/miniconf/load_site_data.py
@@ -9,7 +9,10 @@ import yaml
 def load_site_data(
     site_data_path: str, site_data: Dict[str, Any], by_uid: Dict[str, Any]
 ) -> List[str]:
-    """Load all for your sitedata one time."""
+    """Loads all site data at once.
+
+    Populates the `site_data` and `by_uid` using files under `site_data_path`.
+    """
     extra_files = ["README.md"]
     for f in glob.glob(site_data_path + "/*"):
         extra_files.append(f)

--- a/miniconf/utils.py
+++ b/miniconf/utils.py
@@ -1,0 +1,42 @@
+def extract_list_field(v, key):
+    value = v.get(key, "")
+    if isinstance(value, list):
+        return value
+    else:
+        return value.split("|")
+
+
+def format_paper(v):
+    list_keys = ["authors", "keywords", "session"]
+    list_fields = {}
+    for key in list_keys:
+        list_fields[key] = extract_list_field(v, key)
+
+    return {
+        "id": v["UID"],
+        "forum": v["UID"],
+        "content": {
+            "title": v["title"],
+            "authors": list_fields["authors"],
+            "keywords": list_fields["keywords"],
+            "abstract": v["abstract"],
+            "TLDR": v["abstract"],
+            "recs": [],
+            "session": list_fields["session"],
+            "pdf_url": v.get("pdf_url", ""),
+        },
+    }
+
+
+def format_workshop(v):
+    list_keys = ["authors"]
+    list_fields = {}
+    for key in list_keys:
+        list_fields[key] = extract_list_field(v, key)
+
+    return {
+        "id": v["UID"],
+        "title": v["title"],
+        "organizers": list_fields["authors"],
+        "abstract": v["abstract"],
+    }

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,3 +6,6 @@ strict_optional = False
 [mypy-sklearn.*,transformers.*,flask_frozen.*,flaskext.*,ics.*]
 ignore_missing_imports = True
 
+[mypy-rocketchat_API.*]
+ignore_missing_imports = True
+

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ black==19.10b0
 pylint==2.4.4
 mypy==0.761
 -r scripts/requirements.txt
+-r chat/requirements.txt


### PR DESCRIPTION
The `main.py` gets quite big as we keep adding new pages & logics to it.
Ideally we can follow the "Large Applications" layout recommended [here](https://flask.palletsprojects.com/en/1.1.x/patterns/packages/). However, I don't have a good place to put the code logic for Freezer right now.
As an intermediate step, I move some utils methods from `main.py` to `miniconf/utils.py` and `miniconf/load_site_data.py`.

(It would be nice to follow the "Large Applications" layout in future.)
