### PR TITLE
Match case between CSS and filename for Exo 400 font (+ add ds_store to gitignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ dmypy.json
 
 # node
 node_modules/
+
+# MacOS
+.DS_Store

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,4 @@ static/js/paper_vis.js
 static/js/papers.js
 static/js/persistor.js
 static/js/schedule.js
+static/css/Exo.css

--- a/static/css/Exo.css
+++ b/static/css/Exo.css
@@ -2,5 +2,5 @@
   font-family: "Exo";
   font-style: normal;
   font-weight: 400;
-  src: url(4uazretfpbi4f1zsik9d4ljj4lm3owrmpg.ttf) format("truetype");
+  src: url(4UaZrEtFpBI4f1ZSIK9d4LjJ4lM3OwRmPg.ttf) format("truetype");
 }


### PR DESCRIPTION
Sorry, another very minor change that relates to https://github.com/Mini-Conf/Mini-Conf/pull/70.

There is a case mismatch between a filename in [the Exo.css style](https://github.com/Mini-Conf/Mini-Conf/blob/master/static/css/Exo.css) and [the file itself](https://github.com/Mini-Conf/Mini-Conf/blob/master/static/css/4UaZrEtFpBI4f1ZSIK9d4LjJ4lM3OwRmPg.ttf):

- `4uazretfpbi4f1zsik9d4ljj4lm3owrmpg.ttf` (CSS)
- `4UaZrEtFpBI4f1ZSIK9d4LjJ4lM3OwRmPg.ttf` (file)

This led to a not found error on our server (and the style wasn't rendered). The pull request matches the case (+ I also added `.DS_Store` to the gitignore for mac users).