### PR TITLE
make deploy should not fail if `git branch -D gh-pages` fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,8 @@ format-check:
 	@echo "format-check passed"
 
 deploy: freeze
-	git branch -D gh-pages
-	git branch -D $(TEMP_DEPLOY_BRANCH)
+	-git branch -D gh-pages
+	-git branch -D $(TEMP_DEPLOY_BRANCH)
 	git checkout -b $(TEMP_DEPLOY_BRANCH)
 	git add -f build
 	git commit -am "Deploy on gh-pages"


### PR DESCRIPTION
The `make deploy` recipe includes the following two commands:

```
git branch -D gh-pages
git branch -D $(TEMP_DEPLOY_BRANCH)
```

There are many cases where the branches will not exist before the commands are run (e.g. people starting new projects). In these cases, make fails with something like:

```
git branch -D gh-pages
error: branch 'gh-pages' not found.
make: *** [deploy] Error 1
```

This pull request adds `-` at the start of the commands to ignore the error and avoid failing just because the branch that we are trying to delete doesn't exist. https://www.gnu.org/software/make/manual/html_node/Errors.html

I thought it would be helpful to feed the change back to the repo, but let me know if you would prefer not to be bothered with small changes like this!
