### PR TITLE
Fix broken tests (formatting checks on yaml imports)

### DIFF
--- a/chat/make_poster_rooms.py
+++ b/chat/make_poster_rooms.py
@@ -3,6 +3,7 @@ import csv
 import json
 
 import yaml
+
 from requests import sessions
 from rocketchat_API.rocketchat import RocketChat
 

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ import json
 import os
 
 import yaml
+
 from flask import Flask, jsonify, redirect, render_template, send_from_directory
 from flask_frozen import Freezer
 from flaskext.markdown import Markdown


### PR DESCRIPTION
This pull request fixes the tests, which are failing [with the following error](https://github.com/Mini-Conf/Mini-Conf/runs/858559751):

```
Run make format-check

ERROR: /home/runner/work/Mini-Conf/Mini-Conf/main.py Imports are incorrectly sorted.
ERROR: /home/runner/work/Mini-Conf/Mini-Conf/chat/make_poster_rooms.py Imports are incorrectly sorted.
```

It's fussy, but the linter would like a line break between `import yaml` (an external library) and `from requests import sessions` (local import).