### PR TITLE
Fix broken tests with fixed isort version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 black==19.10b0
+isort==4.3.21
 pylint==2.4.4
 mypy==0.761
 -r scripts/requirements.txt


### PR DESCRIPTION
This is is an attempt to fix the tests, which are failing [with the following error](https://github.com/Mini-Conf/Mini-Conf/runs/858559751):

```
Run make format-check

ERROR: /home/runner/work/Mini-Conf/Mini-Conf/main.py Imports are incorrectly sorted.
ERROR: /home/runner/work/Mini-Conf/Mini-Conf/chat/make_poster_rooms.py Imports are incorrectly sorted.
```

I hope this works...if not, sorry for the spam. I haven't yet replicated the test environment used here, and the tests are passing for me locally.