### PR TITLE
Replaces dead links for Web Archive links (when possible) in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,17 @@
 MiniConf was originally built to host <a href="https://iclr.cc/virtual_2020">ICLR 2020</a> a virtual conference with 6000 participants and have been used to host a wide variety of major conferences.
 
 * AAAI 2021 
-* [ACMC 2020 (Australian Computer Music Conference)](https://acmc2020.com/index.html)
+* [ACMC 2020 (Australian Computer Music Conference)](https://web.archive.org/web/20200907100255/https://acmc2020.com/index.html)
 * [ACM-CHIL 2020 (Conference on Health, Inference, and Learning)](https://www.chilconference.org/)
 * [ACL 2020 (Association of Computational Linguistics)](https://virtual.acl2020.org/index.html)
-* [AIStats 2020](https://aistats2020.net/)
+* [AIStats 2020](https://web.archive.org/web/20201128130620/https://aistats2020.net/)
 * [AKBC 2020 (Automated Knowledge Base Construction)](https://akbc.apps.allenai.org/index.html)
 * [EMNLP 2020 (Empirical Methods in NLP)](https://virtual.2020.emnlp.org/index.html)
 * [ICLR 2020 (International Conference on Learning Representations)](https://iclr.cc/virtual_2020)
 * [ICML 2020 (International Conference on Machine Learning)](https://icml.cc/virtual/2020/index.html)
 * [IEEE VIS 2020 (IEEE conference on Visualization and Visual Analytics)](https://virtual.ieeevis.org/)
 * [NeurIPS 2020 (Neural Information Processing Systems Conference)](https://neurips.cc/virtual/2020/public/)
-* [SIGIR 2020 (Information Retrieval)](https://sigir-schedule.baai.ac.cn/papers)
+* SIGIR 2020 (Information Retrieval)
 * [Data Science Capstone Exhibition, University of Pretoria](https://up-mitc-ds.github.io/808exhibition2020/index.html)
 
 It is designed to be:


### PR DESCRIPTION
Two links to past MiniConf events in the README are pointing to squatted domains:
  * [ACMC 2020 (Australian Computer Music Conference)](https://acmc2020.com/index.html)
  * [AIStats 2020](https://aistats2020.net/)

A third link is dead, with no cached version in the Web Archive
  * [SIGIR 2020 (Information Retrieval)](https://sigir-schedule.baai.ac.cn/papers)

This PR replaces the first two with links to a Web Archive version of the website and removes the link entirely for SIGIR 2020 as I couldn't find a cached version, similar to the mention of AAAI 2021.